### PR TITLE
Extend request options for every endpoint method

### DIFF
--- a/lib/endpoint.js
+++ b/lib/endpoint.js
@@ -69,8 +69,13 @@ Endpoint.prototype.one = function (id, userDefined) {
   return entity;
 };
 
-Endpoint.prototype.list = function (callback) {
-  return this.http.request(this.url(), 'GET', function (err, response, list) {
+Endpoint.prototype.list = function (qs, callback) {
+  var options = {qs: qs};
+  if(typeof qs === 'function') {
+    callback = qs;
+    delete options.qs;
+  }
+  return this.http.request(this.url(), 'GET', options, function (err, response, list) {
     if (callback) callback(err, list);
   });
 };

--- a/lib/endpoint.js
+++ b/lib/endpoint.js
@@ -69,23 +69,21 @@ Endpoint.prototype.one = function (id, userDefined) {
   return entity;
 };
 
-Endpoint.prototype.list = function (qs, callback) {
-  var options = {qs: qs};
-  if(typeof qs === 'function') {
-    callback = qs;
-    delete options.qs;
+Endpoint.prototype.list = function (callback, options) {
+  if (callback && typeof callback === 'object') {
+    options = callback;
+    callback = null;
   }
   return this.http.request(this.url(), 'GET', options, function (err, response, list) {
     if (callback) callback(err, list);
   });
 };
 
-Endpoint.prototype.create = function (payload, callback) {
-  var requestBody = {
-    form: payload
-  };
+Endpoint.prototype.create = function (payload, callback, options) {
+  options = options || {};
+  options.form = payload;
   
-  return this.http.request(this.url(), 'POST', requestBody, function (err, response, body) {
+  return this.http.request(this.url(), 'POST', options, function (err, response, body) {
     if (callback) callback(err, body);
   });
 };

--- a/lib/entity.js
+++ b/lib/entity.js
@@ -53,24 +53,31 @@ Entity.prototype.url = function () {
   return urljoin(this.options.host, this.options.path, this.options.id);
 };
 
-Entity.prototype.get = function (callback) {
-  return this.http.request(this.url(), 'GET', function (err, response, data) {
+Entity.prototype.get = function (callback, options) {
+  if (callback && (typeof callback === 'object')) {
+    options = callback;
+    callback = null;
+  }
+  return this.http.request(this.url(), 'GET', options, function (err, response, data) {
     if (callback) callback(err, data);
   });
 };
 
-Entity.prototype.update = function (payload, callback) {
-  var requestBody = {
-    form: payload
-  };
+Entity.prototype.update = function (payload, callback, options) {
+  options = options || {};
+  options.form = payload;
   
-  return this.http.request(this.url(), 'PUT', requestBody, function (err, response, body) {
+  return this.http.request(this.url(), 'PUT', options, function (err, response, body) {
     if (callback) callback(err, body);
   });
 };
 
-Entity.prototype.remove = function (callback) {
-  return this.http.request(this.url(), 'DELETE', function (err, response, body) {
+Entity.prototype.remove = function (callback, options) {
+  if (callback && (typeof callback === 'object')) {
+    options = callback;
+    callback = null;
+  }
+  return this.http.request(this.url(), 'DELETE', options, function (err, response, body) {
     if (callback) callback(err, body);
   });
 };


### PR DESCRIPTION
Added param `options` to Endpoint and Entry methods (`list`, `get`, `remove`, `create`, `update`).

This will not affect current interface, but will add the possibility to set custom options to the request.
It is useful when we need to set request query strings, or any over [options](https://github.com/request/request#requestoptions-callback).
#### Usage

```
var options = { qs: {limit: 10, offset: 20}};
api.users.list(function(error, data) {
   console.log(data);
}, options);
//--> /api/users?limit=10&offset=20
```
